### PR TITLE
Add get temperatures method

### DIFF
--- a/temperusb/cli.py
+++ b/temperusb/cli.py
@@ -4,22 +4,24 @@ from temperusb.temper import TemperHandler
 import getopt, sys, os.path
 
 def usage():
-    print("%s [-p] [-q] [-c|-f] [-s 0|1|all] [-h|--help]" % os.path.basename(sys.argv[0]))
+    print("%s [-p] [-q] [-c|-f] [-s 0|1|all] [-S 1|2] [-h|--help]" % os.path.basename(sys.argv[0]))
     print("  -q    quiet: only output temperature as a floating number. Usefull for external program parsing")
     print("        this option requires the use of -c or -f")
     print("  -c    with -q, outputs temperature in celcius degrees.")
     print("  -f    with -q, outputs temperature in fahrenheit degrees.")
-    print("  -s    sensor ID 0, 1, or all, to utilize that sensor(s) on the device (multisensor devices only).")
+    print("  -s    sensor ID 0, 1, or all, to utilize that sensor(s) on the device (multisensor devices only).  Default: 0")
+    print("  -S    specify the number of sensors on the device.  Default: 1")
 
 def main():
     try:
-        opts, args = getopt.getopt(sys.argv[1:], ":hpcfqs:", ["help"])
+        opts, args = getopt.getopt(sys.argv[1:], ":hpcfqs:S:", ["help"])
     except getopt.GetoptError as err:
         print(str(err))
         usage()
         sys.exit(2)
     degree_unit = False
-    sensor_id = 0  # Default to first sensor unless specified
+    sensor_count = 1  # Default unless specified otherwise
+    sensor_id = [0,]  # Default to first sensor unless specified
     disp_ports = False
     quiet_output = False
     for o, a in opts:
@@ -41,10 +43,23 @@ def main():
                         raise ValueError(
                             "sensor_id should be 0 or 1, %d given" % sensor_id
                             )
+                    # convert to list
+                    sensor_id = [sensor_id,]
                 except ValueError as err:
                     print(str(err))
                     usage()
                     sys.exit(3)
+        elif o == "-S":
+            try:
+                sensor_count = int(a)
+                if not (sensor_count == 1 or sensor_count == 2):
+                    raise ValueError(
+                        "sensor_count should be 1 or 2, %d given" % sensor_count
+                        )
+            except ValueError as err:
+                print(str(err))
+                usage()
+                sys.exit(4)
         elif o in ("-h", "--help"):
             usage()
             sys.exit()
@@ -55,70 +70,56 @@ def main():
         print('You need to specify unit (-c of -f) when using -q option')
         sys.exit(1)
 
+    # handle the sensor_id "all" option - convert to number of sensors
+    if sensor_id == "all":
+        sensor_id = range(0, sensor_count)
+
+    if not set(sensor_id).issubset(range(0, sensor_count)):
+        print('You specified a sensor_id (-s), without specifying -S with an appropriate number of sensors')
+        sys.exit(5)
+
     th = TemperHandler()
     devs = th.get_devices()
     readings = []
     if not quiet_output:
         print("Found %i devices" % len(devs))
 
-    for i, dev in enumerate(devs):
-        readings.append({'device': i,
-                         'temperature_c': dev.get_temperature(sensor=sensor_id),
-                         'temperature_f':
-                         dev.get_temperature(format="fahrenheit",sensor=sensor_id),
-                         'ports': dev.get_ports(),
-                         'bus': dev.get_bus()
-                         })
+    for dev in devs:
+        dev.set_sensor_count(sensor_count)
+        readings.append(dev.get_temperatures(sensors=sensor_id))
 
-    for reading in readings:
+    for i, reading in enumerate(readings):
+        output = ''
         if quiet_output:
             if degree_unit == 'c':
-                if type(reading['temperature_c']) is float:
-                    print('%0.1f'
-                        % reading['temperature_c'])
-                else:
-                    output = ''
-                    for sensor in reading['temperature_c']:
-                        output += '%0.1f; ' % sensor
-                    output = output[0:len(output) - 2]
-                    print(output)
+                dict_key = 'temperature_c'
             elif degree_unit == 'f':
-                if type(reading['temperature_c']) is float:
-                    print('%0.1f'
-                        % reading['temperature_f'])
-                else:
-                    output = ''
-                    for sensor in reading['temperature_f']:
-                        output += '%0.1f; ' % sensor
-                    output = output[0:len(output) - 2]
-                    print(output)
+                dict_key = 'temperature_f'
             else:
                 raise ValueError('degree_unit expected to be c or f, got %s' % degree_unit)
-        else:
-            if disp_ports:
-                portinfo = " (bus %s - port %s)" % (reading['bus'],
-                                                    reading['ports'])
-            else:
-                portinfo = ""
 
-            if type(reading['temperature_c']) is float:
-                print('Device #%i%s: %0.1f°C %0.1f°F'
-                      % (reading['device'],
-                         portinfo,
-                         reading['temperature_c'],
-                         reading['temperature_f']))
-            else:
-                output = 'Device #%i%s: ' % (
-                    reading['device'],
-                    portinfo,
+            for sensor in sorted(reading):
+                output += '%0.1f; ' % reading[sensor][dict_key]
+            output = output[0:len(output) - 2]
+        else:
+            portinfo = ''
+            tempinfo = ''
+            for sensor in sorted(reading):
+                if disp_ports and portinfo == '':
+                    portinfo = " (bus %s - port %s)" % (reading['bus'],
+                                                        reading['ports'])
+                tempinfo += '%0.1f°C %0.1f°F; ' % (
+                    reading[sensor]['temperature_c'],
+                    reading[sensor]['temperature_f'],
                 )
-                for index in range(0, len(reading['temperature_c'])):
-                    output += '%0.1f°C %0.1f°F; ' % (
-                        reading['temperature_c'][index],
-                        reading['temperature_f'][index],
-                    )
-                output = output[0:len(output) - 2]
-                print(output)
+            tempinfo = tempinfo[0:len(output) - 2]
+
+            output = 'Device #%i%s: %s' % (
+                i,
+                portinfo,
+                tempinfo,
+            )
+        print(output)
 
 if __name__ == '__main__':
     main()

--- a/temperusb/temper.py
+++ b/temperusb/temper.py
@@ -80,13 +80,8 @@ class TemperDevice(object):
     A TEMPer USB thermometer.
     """
     def __init__(self, device, sensor_count=1):
-        # Currently this only supports 1 and 2 sensor models.
-        # If you have the 8 sensor model, please contribute to the
-        # discussion here: https://github.com/padelt/temper-python/issues/19
-        if sensor_count not in [1, 2,]:
-            raise ValueError('Only sensor_count of 1 or 2 supported')
+        self.set_sensor_count(sensor_count)
 
-        self._sensor_count = int(sensor_count)
         self._device = device
         self._bus = device.bus
         self._ports = getattr(device, 'port_number', None)
@@ -125,6 +120,20 @@ class TemperDevice(object):
                             self._offset = offset
         else:
             raise RuntimeError("Must set both scale and offset, or neither")
+
+    def set_sensor_count(self, count):
+        """
+        Set number of sensors on the device.
+
+        To do: revamp /etc/temper.conf file to include this data.
+        """
+        # Currently this only supports 1 and 2 sensor models.
+        # If you have the 8 sensor model, please contribute to the
+        # discussion here: https://github.com/padelt/temper-python/issues/19
+        if count not in [1, 2,]:
+            raise ValueError('Only sensor_count of 1 or 2 supported')
+
+        self._sensor_count = int(count)
 
     def get_ports(self):
         """

--- a/temperusb/temper.py
+++ b/temperusb/temper.py
@@ -206,40 +206,14 @@ class TemperDevice(object):
         """
         Get device temperature reading.
         """
-        # Only supported sensors are 0 and 1 at this stage.
-        # If you have the 8 sensor model, please contribute to the
-        # discussion here: https://github.com/padelt/temper-python/issues/19
-        if sensor not in [0, 1, "all"]:
-            raise ValueError('Only sensor 0 or 1, or the keyword "all" supported')
+        results = self.get_temperatures(sensors=[sensor,])
 
-        if sensor == 0 or sensor == 1:
-            offsets = [(sensor + 1) * 2,]
-        elif sensor == "all":
-            offsets = [2, 4,]
-
-        data = self.get_data()
-
-        # Interpret device response
-        temp_c = []
-        for offset in offsets:
-            data_s = "".join([chr(byte) for byte in data])
-            value = (struct.unpack('>h', data_s[offset:(offset + 2)])[0])
-            temp_c.append(value / 256.0)
-            temp_c[-1] = temp_c[-1] * self._scale + self._offset
-
-        # Return the result or results
         if format == 'celsius':
-            if len(temp_c) == 1:
-                return temp_c[0]
-            return temp_c
+            return results[sensor]['temperature_c']
         elif format == 'fahrenheit':
-            if len(temp_c) == 1:
-                return temp_c[0] * 1.8 + 32.0
-            return [x * 1.8 + 32.0 for x in temp_c]
+            return results[sensor]['temperature_f']
         elif format == 'millicelsius':
-            if len(temp_c) == 1:
-                return int(temp_c[0] * 1000)
-            return [int(x * 1000) for x in temp_c]
+            return results[sensor]['temperature_mc']
         else:
             raise ValueError("Unknown format")
 
@@ -276,7 +250,7 @@ class TemperDevice(object):
             offset = (sensor + 1) * 2
             data_s = "".join([chr(byte) for byte in data])
             value = (struct.unpack('>h', data_s[offset:(offset + 2)])[0])
-            celsius = (125.0 / 32000.0) * value
+            celsius = value / 256.0
             celsius = celsius * self._scale + self._offset
             results[sensor] = {
                 'ports': self.get_ports(),

--- a/temperusb/temper.py
+++ b/temperusb/temper.py
@@ -79,7 +79,14 @@ class TemperDevice(object):
     """
     A TEMPer USB thermometer.
     """
-    def __init__(self, device):
+    def __init__(self, device, sensor_count=1):
+        # Currently this only supports 1 and 2 sensor models.
+        # If you have the 8 sensor model, please contribute to the
+        # discussion here: https://github.com/padelt/temper-python/issues/19
+        if sensor_count not in [1, 2,]:
+            raise ValueError('Only sensor_count of 1 or 2 supported')
+
+        self._sensor_count = int(sensor_count)
         self._device = device
         self._bus = device.bus
         self._ports = getattr(device, 'port_number', None)


### PR DESCRIPTION
This simplifies `temper.py` by:
- introducing a new `get_temperatures()` method
- removes the "all" option for the `sensor` param in the old `get_temperature()` method
- remains backward compatible with v1.x.x of temper-python

This also refactors `cli.py` in a backward compatible way:
- replace the `get_temperature()` calls with a single `get_temperatures()` call
- simplify the generation of the output text
- add the sensor_count command line argument
